### PR TITLE
Fix: Initial path attachment points incorrect on context load

### DIFF
--- a/Munyn/ViewModels/MainViewModel.cs
+++ b/Munyn/ViewModels/MainViewModel.cs
@@ -210,11 +210,23 @@ public partial class MainViewModel : ViewModelBase
             }
             if (node is PathBaseViewModel)
             {
-                ((PathBaseViewModel)node).RecalculatePathData();
+                //((PathBaseViewModel)node).RecalculatePathData(); // Original synchronous call
             }
         }
 
-
+        // After updating VisableNodes and allowing the UI to potentially process it,
+        // schedule a subsequent operation to recalculate paths.
+        // This gives the layout system a chance to measure and arrange node views.
+        Avalonia.Threading.Dispatcher.UIThread.Post(() =>
+        {
+            foreach (ViewModelBase node in VisableNodes)
+            {
+                if (node is PathBaseViewModel pathVM)
+                {
+                    pathVM.RecalculatePathData();
+                }
+            }
+        }, Avalonia.Threading.DispatcherPriority.Background); // Use Background priority to run after layout
     }
 
     private void OnStartConnectionDragFromNode(NodeBaseViewModel sourceNode, Avalonia.Point portCanvasCoordinates, PointerPressedEventArgs e)

--- a/Munyn/Views/NodeCanvasView.axaml.cs
+++ b/Munyn/Views/NodeCanvasView.axaml.cs
@@ -9,14 +9,20 @@ using Munyn.ViewModels;
 
 namespace Munyn.Views;
 
-public partial class NodeCanvasBaseView : Canvas
+public partial class NodeCanvasBaseView : Canvas // Note: XAML root is UserControl, but this class is Canvas. Consider aligning.
 {
-    private readonly ScaleTransform _zoom = new();
-    private readonly TranslateTransform _pan = new();
+    private readonly ScaleTransform _zoom = new(1, 1);
+    private readonly TranslateTransform _pan = new(0, 0);
     private readonly TransformGroup _transform = new();
 
-    private Point _lastDrag;
-    private bool _isDragging;
+    // For Panning
+    private bool _isPanning;
+    private Point _panLastPoint;
+
+    // For Zooming
+    private const double ZoomSpeed = 1.1;
+    private readonly Grid _canvasHost; // Reference to the clipping Grid
+
     public Action<PointerEventArgs> MainViewModelHandleMouseMoved { get; internal set; }
     public Action<PointerReleasedEventArgs> MainViewModelHandleMouseReleased { get; internal set; }
 
@@ -25,8 +31,18 @@ public partial class NodeCanvasBaseView : Canvas
     {
         InitializeComponent();
 
-        NodeCanvasBase.PointerMoved += OnPointerMoved;
-        NodeCanvasBase.PointerReleased += OnPointerReleased;
+        _transform.Children.Add(_pan);
+        _transform.Children.Add(_zoom);
+        NodeCanvasBase.RenderTransform = _transform;
+
+        // Get reference to CanvasHost
+        _canvasHost = this.FindControl<Grid>("CanvasHost") ?? throw new Exception("CanvasHost not found");
+
+
+        NodeCanvasBase.PointerWheelChanged += NodeCanvasBase_PointerWheelChanged;
+        NodeCanvasBase.PointerPressed += NodeCanvasBase_PointerPressed;
+        NodeCanvasBase.PointerMoved += OnPointerMoved; // Existing handler, will be modified
+        NodeCanvasBase.PointerReleased += OnPointerReleased; // Existing handler, will be modified
         
         this.AttachedToVisualTree += OnAttachedToVisualTree;
     }
@@ -34,27 +50,160 @@ public partial class NodeCanvasBaseView : Canvas
 
     private void OnAttachedToVisualTree(object? sender, Avalonia.VisualTreeAttachmentEventArgs e)
     {
-        // Get a reference to the MainWindowViewModel from the DataContext
         if (this.DataContext is MainViewModel mainViewModel)
         {
             MainViewModelHandleMouseMoved = mainViewModel.HandlePointerMoved;
             MainViewModelHandleMouseReleased = mainViewModel.OnEndConnectionDragFromNode;
-
             mainViewModel.NodeCanvasBase = NodeCanvasBase;
         }
-
-        // Attach to LayoutUpdated to wait for the layout pass
         NodeCanvasBase.LayoutUpdated += OnLayoutUpdated;
+    }
+
+    private void NodeCanvasBase_PointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (e.GetCurrentPoint(this).Properties.IsRightButtonPressed)
+        {
+            if (_canvasHost == null) return;
+
+            _isPanning = true;
+            _panLastPoint = e.GetPosition(_canvasHost); // Use position relative to CanvasHost for panning
+            NodeCanvasBase?.CapturePointer(e.Pointer);
+            e.Handled = true;
+        }
+    }
+
+    private void NodeCanvasBase_PointerWheelChanged(object? sender, PointerWheelEventArgs e)
+    {
+        if (_canvasHost == null || NodeCanvasBase == null) return;
+
+        var point = e.GetPosition(NodeCanvasBase); // Mouse position relative to the NodeCanvasBase
+        var pointToHost = e.GetPosition(_canvasHost); // Mouse position relative to the CanvasHost (viewport)
+
+        double scale = e.Delta.Y > 0 ? ZoomSpeed : 1 / ZoomSpeed;
+
+        double oldScaleX = _zoom.ScaleX;
+        double oldScaleY = _zoom.ScaleY;
+
+        _zoom.ScaleX *= scale;
+        _zoom.ScaleY *= scale;
+
+        // Adjust pan to keep the point under the mouse stationary relative to the viewport
+        // The pan adjustment is the difference in the mouse position's mapping to canvas coordinates
+        // before and after the zoom, scaled by the new zoom level.
+        _pan.X = pointToHost.X - (point.X * _zoom.ScaleX);
+        _pan.Y = pointToHost.Y - (point.Y * _zoom.ScaleY);
+
+        ConstrainView(); // To be implemented in Step 4
+        e.Handled = true;
     }
 
     private void OnPointerMoved(object? sender, PointerEventArgs e)
     {
-        MainViewModelHandleMouseMoved(e);
+        if (_isPanning && NodeCanvasBase?.IsPointerCaptured(e.Pointer) == true)
+        {
+            if (_canvasHost == null) return;
+
+            var currentPoint = e.GetPosition(_canvasHost);
+            var delta = currentPoint - _panLastPoint;
+            _panLastPoint = currentPoint;
+
+            _pan.X += delta.X;
+            _pan.Y += delta.Y;
+
+            ConstrainView(); // To be implemented in Step 4
+            e.Handled = true;
+        }
+        else
+        {
+            MainViewModelHandleMouseMoved?.Invoke(e);
+        }
     }
 
     private void OnPointerReleased(object? sender, PointerReleasedEventArgs e)
     {
-        MainViewModelHandleMouseReleased(e);
+        if (_isPanning && NodeCanvasBase?.IsPointerCaptured(e.Pointer) == true)
+        {
+            _isPanning = false;
+            NodeCanvasBase.ReleasePointerCapture(e.Pointer);
+            e.Handled = true;
+        }
+        else
+        {
+            MainViewModelHandleMouseReleased?.Invoke(e);
+        }
+    }
+
+    private void ConstrainView()
+    {
+        if (NodeCanvasBase == null || _canvasHost == null || _canvasHost.Bounds.Width <= 0 || _canvasHost.Bounds.Height <= 0)
+        {
+            return; // Not ready to constrain yet
+        }
+
+        var canvasHostBounds = _canvasHost.Bounds;
+        // NodeCanvasBase.Bounds is the original, untransformed size (e.g., 3000x3000)
+        var nodeCanvasOriginalBounds = NodeCanvasBase.Bounds;
+
+        if (nodeCanvasOriginalBounds.Width <= 0 || nodeCanvasOriginalBounds.Height <= 0)
+        {
+            return; // Original canvas size is not valid
+        }
+
+        // 1. Zoom Constraints: Prevent zooming out too much
+        double minScaleX = canvasHostBounds.Width / nodeCanvasOriginalBounds.Width;
+        if (_zoom.ScaleX < minScaleX)
+        {
+            _zoom.ScaleX = minScaleX;
+        }
+
+        double minScaleY = canvasHostBounds.Height / nodeCanvasOriginalBounds.Height;
+        if (_zoom.ScaleY < minScaleY)
+        {
+            _zoom.ScaleY = minScaleY;
+        }
+
+        // Optional: Max zoom constraint (e.g., _zoom.ScaleX > 2.0) can be added here if needed.
+
+        // Calculate effective width and height of the NodeCanvasBase after zoom
+        double effectiveWidth = nodeCanvasOriginalBounds.Width * _zoom.ScaleX;
+        double effectiveHeight = nodeCanvasOriginalBounds.Height * _zoom.ScaleY;
+
+        // 2. Pan Constraints
+        // Left edge: _pan.X cannot be positive (content shifted right, showing background on the left)
+        if (_pan.X > 0)
+        {
+            _pan.X = 0;
+        }
+
+        // Top edge: _pan.Y cannot be positive (content shifted down, showing background on the top)
+        if (_pan.Y > 0)
+        {
+            _pan.Y = 0;
+        }
+
+        // Right edge: The right side of the canvas (_pan.X + effectiveWidth) should not be less than the host width.
+        // This means _pan.X should not be less than canvasHostBounds.Width - effectiveWidth.
+        double minPanX = canvasHostBounds.Width - effectiveWidth;
+        if (effectiveWidth <= canvasHostBounds.Width) // If canvas is narrower than or same width as host
+        {
+            _pan.X = 0; // Center it or align left
+        }
+        else if (_pan.X < minPanX)
+        {
+            _pan.X = minPanX;
+        }
+
+        // Bottom edge: The bottom side of the canvas (_pan.Y + effectiveHeight) should not be less than the host height.
+        // This means _pan.Y should not be less than canvasHostBounds.Height - effectiveHeight.
+        double minPanY = canvasHostBounds.Height - effectiveHeight;
+        if (effectiveHeight <= canvasHostBounds.Height) // If canvas is shorter than or same height as host
+        {
+            _pan.Y = 0; // Center it or align top
+        }
+        else if (_pan.Y < minPanY)
+        {
+            _pan.Y = minPanY;
+        }
     }
 
 

--- a/Munyn/Views/Nodes/NodeBaseView.cs
+++ b/Munyn/Views/Nodes/NodeBaseView.cs
@@ -57,45 +57,67 @@ public partial class NodeBaseView : UserControl
 
     public void Node_PointerMoved(object sender, PointerEventArgs e)
     {
-        Point currentCanvasPosition = e.GetPosition(_rootDrawingCanvas);
+        if (DataContext is not NodeBaseViewModel viewModel) return;
 
-
-        if (!_isDragging && e.Pointer.Captured == (this))
+        if (_rootDrawingCanvas == null)
         {
-            double deltaX = currentCanvasPosition.X - _startDragPoint.X;
-            double deltaY = currentCanvasPosition.Y - _startDragPoint.Y;
-            double distance = Math.Sqrt(deltaX * deltaX + deltaY * deltaY);
-
-            if (distance > DragThreshold)
-                _isDragging = true;
-
-        }
-
-        if (_isDragging && DataContext is NodeBaseViewModel viewModel)
-        {
-            // Get the current position of the mouse relative to the Canvas
-            // Find the parent Canvas
-
+            _rootDrawingCanvas = viewModel.parentCanvas;
             if (_rootDrawingCanvas == null)
             {
-                _rootDrawingCanvas = viewModel.parentCanvas;
-                if (_rootDrawingCanvas == null) return;
+                // Cannot perform drag operations without the root canvas
+                return;
             }
+        }
 
+        Point currentPointerPosOnCanvas = e.GetPosition(_rootDrawingCanvas);
 
-            // Calculate the new X and Y based on the mouse movement and initial click offset
-            // Current mouse position on canvas - initial click offset relative to node
-            double newX = currentCanvasPosition.X - _startDragPoint.X;
-            double newY = currentCanvasPosition.Y - _startDragPoint.Y;
+        if (!_isDragging && e.Pointer.Captured == this)
+        {
+            // _startDragPoint is the offset within the node where the pointer was pressed.
+            // viewModel.X and viewModel.Y is the node's current top-left position on the canvas.
+            Point initialPointerPosOnCanvasAtPress = new Point(viewModel.X + _startDragPoint.X, viewModel.Y + _startDragPoint.Y);
 
-            // Optional: Clamp values to stay within canvas bounds (adjust as needed)
+            // Calculate distance moved on the canvas
+            if ((currentPointerPosOnCanvas - initialPointerPosOnCanvasAtPress).Length > DragThreshold)
+            {
+                _isDragging = true;
+            }
+        }
+
+        if (_isDragging && e.Pointer.Captured == this) // Ensure pointer is still captured by this control
+        {
+            // currentPointerPosOnCanvas is already up-to-date and relative to _rootDrawingCanvas.
+            // _startDragPoint is the click offset within the node.
+            double newX = currentPointerPosOnCanvas.X - _startDragPoint.X;
+            double newY = currentPointerPosOnCanvas.Y - _startDragPoint.Y;
+
+            // Clamping: Ensure node stays within canvas bounds
             newX = Math.Max(0, newX);
             newY = Math.Max(0, newY);
-            newX = Math.Min(_rootDrawingCanvas.Bounds.Width - Bounds.Width, newX);
-            newY = Math.Min(_rootDrawingCanvas.Bounds.Height - Bounds.Height, newY);
 
+            // Use this.Bounds for the node's own dimensions.
+            // Ensure Bounds are valid before using them in Min function.
+            double nodeWidth = this.Bounds.Width;
+            double nodeHeight = this.Bounds.Height;
 
-            // Update the ViewModel properties
+            if (nodeWidth > 0)
+            {
+                newX = Math.Min(_rootDrawingCanvas.Bounds.Width - nodeWidth, newX);
+            }
+            else // Fallback if nodeWidth is not positive (e.g. not laid out yet)
+            {
+                newX = Math.Min(_rootDrawingCanvas.Bounds.Width, newX);
+            }
+
+            if (nodeHeight > 0)
+            {
+                newY = Math.Min(_rootDrawingCanvas.Bounds.Height - nodeHeight, newY);
+            }
+            else // Fallback if nodeHeight is not positive
+            {
+                newY = Math.Min(_rootDrawingCanvas.Bounds.Height, newY);
+            }
+
             viewModel.X = newX;
             viewModel.Y = newY;
             //System.Diagnostics.Debug.WriteLine($"PointerMoved: newX={newX}, newY={newY}");


### PR DESCRIPTION
Resolved an issue where paths would attach to node corners (e.g., top-left) when a context was first loaded, only correcting after a connected node was dragged.

The bug was caused by `PathBaseViewModel.RecalculatePathData()` being called synchronously during `MainViewModel.RefreshContext()` before the node views had completed their UI layout pass. This resulted in node view dimensions (Bounds.Width/Height) being reported as zero or uninitialized, leading to incorrect path endpoint calculations.

The fix defers the call to `RecalculatePathData()` for all visible paths by posting it to the `Dispatcher.UIThread` with `Background` priority at the end of `RefreshContext()`. This ensures that the recalculation happens after the layout system has had a chance to measure and arrange the node views, providing accurate dimensions for path calculations.