### PR TITLE
feat: Add ability to delete paths with backspace key

### DIFF
--- a/Munyn/ViewModels/Paths/PathBaseViewModel.cs
+++ b/Munyn/ViewModels/Paths/PathBaseViewModel.cs
@@ -2,6 +2,8 @@
 using Avalonia; // For Point, Rect
 using System;
 using System.Globalization; // For InvariantCulture
+using Avalonia.Input;
+using Avalonia.Media;
 
 namespace Munyn.ViewModels
 {
@@ -16,6 +18,23 @@ namespace Munyn.ViewModels
         [ObservableProperty]
         private string _pathData = "M 0,0 C 0,0 0,0 0,0"; // Default empty path
 
+        [ObservableProperty]
+        private bool _isSelected = false;
+
+        [ObservableProperty]
+        private IBrush _selectedStrokeBrush;
+
+        public Action<PathBaseViewModel, PointerPressedEventArgs> OnClickedPath { get; internal set; }
+
+
+        public void SetSelected(bool selected)
+        {
+            IsSelected = selected;
+            if (IsSelected)
+                SelectedStrokeBrush = new SolidColorBrush(Color.Parse("#A0A0FF"));
+            else
+                SelectedStrokeBrush = new SolidColorBrush(Color.Parse("#f2f2f2"));
+        }
         // Properties for XAML binding to draw the line (now primarily for calculating PathData)
 
 
@@ -31,7 +50,7 @@ namespace Munyn.ViewModels
             StartNode = startNode;
             StartPoint = new Point(StartNode.X, StartNode.Y);
             EndPoint = endPoint;
-
+            SetSelected(false);
 
 
             RecalculatePathData(); // Initial calculation

--- a/Munyn/Views/MainView.axaml
+++ b/Munyn/Views/MainView.axaml
@@ -11,7 +11,8 @@
 			 xmlns:panels="clr-namespace:Munyn.Panels;assembly=Munyn"
 			 mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="Munyn.Views.MainView"
-             x:DataType="vm:MainViewModel">
+             x:DataType="vm:MainViewModel"
+			 Focusable="True">
 
 
 	<UserControl.Resources>
@@ -24,7 +25,7 @@
 			<nodes:NodeView DataContext="{Binding}"/>
 		</DataTemplate>
 		<DataTemplate DataType="vm:PathBaseViewModel">
-			<Path Data="{Binding PathData}" Stroke="#f2f2f2" StrokeThickness="2"/>
+			<Path Data="{Binding PathData}" Stroke="{Binding SelectedStrokeBrush}" StrokeThickness="4" PointerPressed="Path_OnPointerPressed"/>
 		</DataTemplate>
 	</UserControl.DataTemplates>
 	

--- a/Munyn/Views/MainView.axaml.cs
+++ b/Munyn/Views/MainView.axaml.cs
@@ -50,6 +50,7 @@ public partial class MainView : UserControl
         this.PointerPressed += OnPointerPressed;
         this.SizeChanged += OnSizeChanged;
         this.PointerWheelChanged += MainView_PointerWheelChanged;
+        this.KeyDown += MainView_OnKeyDown;
     }
 
     private void OnSizeChanged(object? sender, SizeChangedEventArgs e)
@@ -288,6 +289,29 @@ public partial class MainView : UserControl
         translateTransform.Y = newY;
 
         e.Handled = true;
+    }
+
+    private void MainView_OnKeyDown(object? sender, KeyEventArgs e)
+    {
+        if (e.Key == Key.Back)
+        {
+            if (DataContext is MainViewModel mainVm)
+            {
+                mainVm.DeleteSelectedPathCommand.Execute(null);
+                mainVm.DeleteSelectedNodeCommand.Execute(null);
+            }
+        }
+    }
+
+    private void Path_OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (sender is Path path && path.DataContext is PathBaseViewModel pathVm)
+        {
+            if (DataContext is MainViewModel mainVm)
+            {
+                mainVm.OnClickedPath(pathVm, e);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This commit introduces the ability for you to select a path by clicking on it and then delete it by pressing the backspace key.

The implementation includes:
- Modifications to `PathBaseViewModel` to support a selected state.
- Updates to `MainViewModel` to manage path selection and deletion logic.
- Changes to `MainView.axaml` to enable path interaction and visual feedback for selection.
- Implementation of event handlers in `MainView.axaml.cs` to handle path clicks and backspace key presses.