### PR TITLE
Fix: Add parameterless constructor to NodePropertyBasic

### DIFF
--- a/Munyn/ViewModels/Nodes/Properties/NodeProperties.cs
+++ b/Munyn/ViewModels/Nodes/Properties/NodeProperties.cs
@@ -45,6 +45,10 @@ namespace Munyn.ViewModels.Nodes.Properties
         }
 
 
+        public NodePropertyBasic() : this("New Property")
+        {
+        }
+
         public NodePropertyBasic(string propertyName = "New Property", bool isDefault = false, bool isVisiableOnGraphNode = false, bool isEditable = true)
         {
             PropertyName = propertyName;


### PR DESCRIPTION
Adds a parameterless constructor to the `NodePropertyBasic` class to resolve a `System.MissingMethodException`.

The crash occurred when adding a new basic property to a node, because `Activator.CreateInstance` was used to create an instance of `NodePropertyBasic`, which did not have a parameterless constructor. The new constructor chains to the existing one with default values.