### PR TITLE
Fix: Correct namespace for NodeGraphPropertyMultiInterfaceView

### DIFF
--- a/Munyn/Views/Nodes/NodeDetails/Properties/GraphView/NodeGraphPropertyMultiInterfaceView.axaml
+++ b/Munyn/Views/Nodes/NodeDetails/Properties/GraphView/NodeGraphPropertyMultiInterfaceView.axaml
@@ -3,7 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
-             x:Class="Munyn.Views.Nodes.NodeDetails.NodeGraphPropertyMultiInterfaceView">
+             x:Class="Munyn.Views.Nodes.NodeDetails.Properties.GraphView.NodeGraphPropertyMultiInterfaceView">
 
 
 	<StackPanel Margin="10">

--- a/Munyn/Views/Nodes/NodeDetails/Properties/GraphView/NodeGraphPropertyMultiInterfaceView.axaml.cs
+++ b/Munyn/Views/Nodes/NodeDetails/Properties/GraphView/NodeGraphPropertyMultiInterfaceView.axaml.cs
@@ -2,7 +2,8 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
 
-namespace Munyn.Views.Nodes.NodeDetails;
+namespace Munyn.Views.Nodes.NodeDetails.Properties.GraphView;
+
 public partial class NodeGraphPropertyMultiInterfaceView : UserControl
 {
     public NodeGraphPropertyMultiInterfaceView()


### PR DESCRIPTION
The build was failing because the namespace for NodeGraphPropertyMultiInterfaceView was incorrect in both the `.axaml` and `.axaml.cs` files. This caused the XAML compiler to be unable to resolve the type.

This change corrects the namespace in both files to `Munyn.Views.Nodes.NodeDetails.Properties.GraphView`, which allows the project to build successfully.