### PR TITLE
Fix: Remove LayoutUpdated event handler to prevent infinite loop

### DIFF
--- a/Munyn/Views/Nodes/NodeView.axaml.cs
+++ b/Munyn/Views/Nodes/NodeView.axaml.cs
@@ -20,16 +20,6 @@ public partial class NodeView : UserControl
     public NodeView()
     {
         InitializeComponent();
-        this.LayoutUpdated += NodeView_LayoutUpdated;
-    }
-
-    private void NodeView_LayoutUpdated(object? sender, EventArgs e)
-    {
-        if (DataContext is NodeBaseViewModel viewModel)
-        {
-            foreach (PathBaseViewModel path in viewModel.connectedPaths)
-                path.RecalculatePathData();
-        }
     }
     public void Node_PointerPressed(object sender, PointerPressedEventArgs e)
     {


### PR DESCRIPTION
The `LayoutUpdated` event handler in `NodeView.axaml.cs` was calling `RecalculatePathData`, which was causing an infinite layout loop. The path's geometry was being calculated based on the node's bounds, and the new path geometry was causing the layout to be invalidated, which would trigger the `LayoutUpdated` event again.

This commit removes the `LayoutUpdated` event handler. The `RecalculatePathData` method is still called when a node is moved, which is the correct behavior.